### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darkli…

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,12 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="List of movies, documentaries and TV series about hackers, geeks and IT in common, sorted by IMDB rating.">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="vendor/themes/vue.css">
+  <link 
+    rel="stylesheet"
+    href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+    title="docsify-darklight-theme"
+    type="text/css"
+  />
 </head>
 
 <body>
@@ -19,6 +24,10 @@
     logo: '/logos/logo_static.png',
     repo: 'https://github.com/greybax/awesome-IT-films'
   }
+</script>
+<script 
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+    type="text/javascript">
 </script>
 <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>


### PR DESCRIPTION
Enabled dark and light mode with switch for docs using docsify-darklight-theme with redesigned search bar. For more customization [see here](https://boopathikumar018.github.io/docsify-darklight-theme)

**Light Mode :**

Before 

![image](https://user-images.githubusercontent.com/10001746/79608819-462df480-8113-11ea-8dcf-c65f3f868c39.png)


After

![image](https://user-images.githubusercontent.com/10001746/79608893-61006900-8113-11ea-9fb5-363dc0aa6cc0.png)

**Dark Mode :**

![image](https://user-images.githubusercontent.com/10001746/79608934-737aa280-8113-11ea-83f1-a916826c64aa.png)

