### PR TITLE
Page fix not found due to missing 'build/' directory

### DIFF
--- a/build/documentary.md
+++ b/build/documentary.md
@@ -7,9 +7,9 @@
 
 ## Contents
 
-- [TV Series](tv_series.md)
-- [Movies](movies.md)
-- [Documentary](documentary.md)
+- [TV Series](build/tv_series.md)
+- [Movies](build/movies.md)
+- [Documentary](build/documentary.md)
 
 - [8.0-8.5 :star:](#_80-85)
   - [The Triumph of the Nerds: The Rise of Accidental Empires](#the-triumph-of-the-nerds-the-rise-of-accidental-empires)

--- a/build/movies.md
+++ b/build/movies.md
@@ -7,9 +7,9 @@
 
 ## Contents
 
-- [Documentary](documentary.md)
-- [TV Series](tv_series.md)
-- [Movies](movies.md)
+- [Documentary](build/documentary.md)
+- [TV Series](build/tv_series.md)
+- [Movies](build/movies.md)
 
 - [8.5-8.9 :star:](#_85-89)
   - [Matrix](#matrix)

--- a/build/tv_series.md
+++ b/build/tv_series.md
@@ -7,9 +7,9 @@
 
 ## Contents
 
-- [Movies](movies.md)
-- [Documentary](documentary.md)
-- [TV Series](tv_series.md)
+- [Movies](build/movies.md)
+- [Documentary](build/documentary.md)
+- [TV Series](build/tv_series.md)
 
 - [8.5-8.9 :star:](#_85-89)
   - [Black Mirror](#black-mirror)


### PR DESCRIPTION
The movies, documentary and TV series links now work within their respective pages.